### PR TITLE
feat(treesitter): use `auto_install` to install missing parser

### DIFF
--- a/lua/lazyvim/plugins/treesitter.lua
+++ b/lua/lazyvim/plugins/treesitter.lua
@@ -33,6 +33,7 @@ return {
     ---@type TSConfig
     opts = {
       highlight = { enable = true },
+      auto_install = true,
       indent = { enable = true },
       context_commentstring = { enable = true, enable_autocmd = false },
       ensure_installed = {


### PR DESCRIPTION
even though it recommend "set to false if you don't have `tree-sitter` CLI installed locally", it actually works perfectly